### PR TITLE
Fix arrow label position on Chrome

### DIFF
--- a/src/sequence-diagram/ArrowLabel.js
+++ b/src/sequence-diagram/ArrowLabel.js
@@ -8,36 +8,34 @@ const ArrowLabel = ({ prefix, label, theme, length }) => {
   const { x, y } = getArrowLabelCoordinates(theme)
 
   return (
-    <svg transform={`translate(${x}, ${y})`}>
-      <g>
-        <foreignObject width={length} height={labelHeight}>
-          <div
+    <g transform={`translate(${x}, ${y})`}>
+      <foreignObject width={length} height={labelHeight}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'flex-end',
+            height: '100%'
+          }}>
+          <p
             style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'flex-end',
-              height: '100%'
+              fontStyle: 'italic',
+              fontSize: labelFontSize,
+              lineHeight: labelLineHeight,
+              margin: 0,
+              textAlign: 'center',
+              userSelect: 'none',
+              wordBreak: 'break-all',
+              WebkitLineClamp: labelLines,
+              WebkitBoxOrient: 'vertical',
+              display: '-webkit-box'
             }}>
-            <p
-              style={{
-                fontStyle: 'italic',
-                fontSize: labelFontSize,
-                lineHeight: labelLineHeight,
-                margin: 0,
-                textAlign: 'center',
-                userSelect: 'none',
-                wordBreak: 'break-all',
-                WebkitLineClamp: labelLines,
-                WebkitBoxOrient: 'vertical',
-                display: '-webkit-box'
-              }}>
-              {prefix} <br />
-              {label}
-            </p>
-          </div>
-        </foreignObject>
-      </g>
-    </svg>
+            {prefix} <br />
+            {label}
+          </p>
+        </div>
+      </foreignObject>
+    </g>
   )
 }
 

--- a/src/sequence-diagram/ArrowLabel.test.js
+++ b/src/sequence-diagram/ArrowLabel.test.js
@@ -6,14 +6,18 @@ const theme = { arrow: { labelFontSize: 12, labelLineHeight: 1.5, labelLines: 2 
 
 test('renders label', () => {
   const { getByText } = render(
-    <ArrowLabel label={'/api/orders/1'} length={10} width={10} theme={theme} />
+    <svg>
+      <ArrowLabel label={'/api/orders/1'} length={10} width={10} theme={theme} />
+    </svg>
   )
   expect(getByText('/api/orders/1')).toBeInTheDocument()
 })
 
 test('optionally renders prefix', () => {
   const { getByText } = render(
-    <ArrowLabel prefix={'GET'} label={'/api/orders/1'} length={10} width={10} theme={theme} />
+    <svg>
+      <ArrowLabel prefix={'GET'} label={'/api/orders/1'} length={10} width={10} theme={theme} />
+    </svg>
   )
   expect(getByText(/GET/i)).toBeInTheDocument()
 })


### PR DESCRIPTION
The commit 5b8adb856bd4085c1f4cf934d19ece98aafcadeb messed with the rendering position of the arrow label on Chrome. More specifically, the commit wrapped the `<g>` tag on ArrowLabel with a `<svg>` so that jest wouldn't complain of unknown `<g>` elements on test. 

Jest does that because it has no way of knowing, from the unit test, that on production there's actually another component wrapping it with a `svg` tag. However, this made the sequence diagram itself to now have nested svg elements, and unfortunatelly, browsers don't handle that consistently. 

On Firefox the svg coordinate system kept working just fine, but on Chrome the svg nesting resulted in changing the position of the arrow label, causing the bug we observed.

This commit fix that issue by removing the svg wrapping from the source code and, instead, adding it to the ArrowLabel test, so jest gets happy, Chromes gets happy and everybody wins.